### PR TITLE
feat(rector): enable rector with the shared org config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,15 @@ jobs:
     permissions:
       contents: read
     with:
-      php-versions: '["8.1","8.2","8.3","8.4","8.5"]'
+      # First entry drives the non-matrixed tool jobs (CGL, Rector), so it has to
+      # stay >= 8.2: netresearch/typo3-ci-workflows requires php ^8.2 and those
+      # jobs install the full require-dev. 8.1 stays in the matrix as the floor.
+      php-versions: '["8.2","8.1","8.3","8.4","8.5"]'
       typo3-versions: '["^12.4","^13.4"]'
       matrix-exclude: '[{"php":"8.1","typo3":"^13.4"},{"php":"8.5","typo3":"^12.4"}]'
+      # The meta package is unresolvable under typo3/cms-core ^12.4, so the ^12.4
+      # cells drop it. The Rector job is not TYPO3-matrixed and keeps it.
+      remove-dev-deps: '[{"dep":"netresearch/typo3-ci-workflows","only-for":"^13.4|^14.3"}]'
       run-functional-tests: true
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -4,6 +4,19 @@ declare(strict_types=1);
 
 $config = \TYPO3\CodingStandards\CsFixerConfig::create();
 
+// TYPO3 coding-standards fully qualifies global classes (import_classes =>
+// false), while the shared org Rector config calls importNames() and imports
+// them. Left as-is the two tools undo each other on every run. The org
+// PHP-CS-Fixer baseline (netresearch/typo3-ci-workflows
+// config/php-cs-fixer/rules.php) imports, so align with that.
+$config->addRules([
+    'global_namespace_import' => [
+        'import_classes'   => true,
+        'import_constants' => true,
+        'import_functions' => true,
+    ],
+]);
+
 $config->setFinder(
     (new PhpCsFixer\Finder())
         ->ignoreVCSIgnored(true)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ TYPO3 extension for SAML 2.0 Single Sign-On authentication. Supports TYPO3 12.4/
 ```bash
 composer ci:test:php:cgl          # PHP-CS-Fixer (dry-run)
 composer ci:test:php:phpstan     # PHPStan level 6
+composer ci:test:php:rector      # Rector (dry-run, shared org config)
 composer ci:test:php:unit        # Unit tests
 composer ci:test:php:functional  # Functional tests (requires typo3DatabaseDriver=pdo_sqlite)
 ```

--- a/Build/rector.php
+++ b/Build/rector.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the package netresearch/nr-saml-auth.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPublicMethodParameterRector;
+use Rector\ValueObject\PhpVersion;
+
+$configure = require_once __DIR__ . '/../.Build/vendor/netresearch/typo3-ci-workflows/config/rector/rector.php';
+
+return static function (RectorConfig $rectorConfig) use ($configure): void {
+    // Shared org base config: code-quality sets, rule skips, phpstan-rector.neon
+    $configure($rectorConfig, __DIR__ . '/..');
+
+    // The extension requires php ^8.1 and CI runs a PHP 8.1 cell, so the shared
+    // default of 8.2 must be lowered: it lets rules emit 8.2-only syntax
+    // (ReadOnlyClassRector turns the event listeners into `final readonly class`),
+    // which is a parse error on 8.1.
+    $rectorConfig->phpVersion(PhpVersion::PHP_81);
+
+    // paths() replaces the shared list — re-declared to keep Tests/ in scope,
+    // which the shared $projectRoot default leaves out.
+    $rectorConfig->paths(array_merge(
+        [
+            __DIR__ . '/../Classes',
+            __DIR__ . '/../Configuration',
+            __DIR__ . '/../Resources',
+            __DIR__ . '/../Tests',
+        ],
+        glob(__DIR__ . '/../ext_*.php') ?: [],
+    ));
+
+    $rectorConfig->skip([
+        // The event listeners are registered with an explicit `event:` key, so
+        // TYPO3 calls __invoke($event) regardless of the signature — but a PSR-14
+        // listener has to accept the event it is registered for, and dropping the
+        // parameter turns the tag-based registration in Services.yaml into a
+        // container build error as soon as the event is derived from the signature.
+        RemoveUnusedPublicMethodParameterRector::class => [
+            __DIR__ . '/../Classes/EventListener',
+        ],
+    ]);
+};

--- a/Classes/Controller/AuthController.php
+++ b/Classes/Controller/AuthController.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace Netresearch\NrSamlAuth\Controller;
 
-use Netresearch\NrSamlAuth\Domain\Repository\SettingsRepository;
+use Exception;
 use Netresearch\NrSamlAuth\Service\SamlService;
+use OneLogin\Saml2\Error;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use TYPO3\CMS\Core\Authentication\LoginType;
@@ -19,7 +20,6 @@ use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
 class AuthController extends ActionController
 {
     public function __construct(
-        private readonly SettingsRepository $settingsRepository,
         private readonly SamlService $samlService,
         private readonly Context $context,
         private readonly LoggerInterface $logger,
@@ -28,7 +28,7 @@ class AuthController extends ActionController
     /**
      * Login action - initiates SAML SSO flow or displays logged-in state
      *
-     * @throws \OneLogin\Saml2\Error
+     * @throws Error
      */
     public function loginAction(): ResponseInterface
     {
@@ -61,7 +61,7 @@ class AuthController extends ActionController
     {
         try {
             return (bool)$this->context->getPropertyFromAspect('frontend.user', 'isLoggedIn');
-        } catch (\Exception $exception) {
+        } catch (Exception $exception) {
             $this->logger->error('Error checking login state', ['exception' => $exception->getMessage()]);
             return false;
         }

--- a/Classes/EventListener/AfterUserLoggedInEventListener.php
+++ b/Classes/EventListener/AfterUserLoggedInEventListener.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrSamlAuth\EventListener;
 
+use Exception;
 use Netresearch\NrSamlAuth\Service\SamlService;
 use Netresearch\NrSamlAuth\Session\SamlSession;
 use Psr\Http\Message\ServerRequestInterface;
@@ -32,7 +33,7 @@ final class AfterUserLoggedInEventListener
     public function __invoke(AfterUserLoggedInEvent $event): void
     {
         $request = $this->getRequest();
-        if ($request === null) {
+        if (!$request instanceof ServerRequestInterface) {
             return;
         }
 
@@ -57,7 +58,7 @@ final class AfterUserLoggedInEventListener
 
             $this->samlSession->setUser($event->getUser());
             $this->samlSession->setSessionData($sessionData);
-        } catch (\Exception $exception) {
+        } catch (Exception $exception) {
             $this->logger->error('Failed to store SAML session data', [
                 'exception' => $exception->getMessage(),
             ]);

--- a/Classes/EventListener/AfterUserLoggedOutEventListener.php
+++ b/Classes/EventListener/AfterUserLoggedOutEventListener.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrSamlAuth\EventListener;
 
+use Exception;
 use Netresearch\NrSamlAuth\Service\SamlService;
 use Psr\Log\LoggerInterface;
 use TYPO3\CMS\Core\Attribute\AsEventListener;
@@ -38,7 +39,7 @@ final class AfterUserLoggedOutEventListener
 
             $this->samlService->setSettingsUid((int)$samlId);
             $this->samlService->redirectUserToLogout($nameId, $assertionId);
-        } catch (\Exception $exception) {
+        } catch (Exception $exception) {
             $this->logger->error('SAML logout failed', [
                 'exception' => $exception->getMessage(),
             ]);

--- a/Classes/Middleware/DeepLinkSsoMiddleware.php
+++ b/Classes/Middleware/DeepLinkSsoMiddleware.php
@@ -38,7 +38,11 @@ final class DeepLinkSsoMiddleware implements MiddlewareInterface
 
     private function isResponsible(ServerRequestInterface $request): bool
     {
-        return $this->isSamlLoginRequest($request) || $this->isSamlLogoutRequest($request);
+        if ($this->isSamlLoginRequest($request)) {
+            return true;
+        }
+
+        return $this->isSamlLogoutRequest($request);
     }
 
     private function getRedirectTarget(ServerRequestInterface $request): ?string

--- a/Classes/Service/SamlService.php
+++ b/Classes/Service/SamlService.php
@@ -8,9 +8,13 @@ use Netresearch\NrSamlAuth\Domain\Model\Settings;
 use Netresearch\NrSamlAuth\Domain\Repository\SettingsRepository;
 use OneLogin\Saml2\Auth;
 use OneLogin\Saml2\Constants;
+use OneLogin\Saml2\Error;
 use OneLogin\Saml2\Metadata;
 use OneLogin\Saml2\Response;
 use OneLogin\Saml2\Settings as SamlSettings;
+use OneLogin\Saml2\ValidationError;
+use ReflectionClass;
+use ReflectionException;
 use TYPO3\CMS\Core\SingletonInterface;
 
 /**
@@ -65,7 +69,7 @@ final class SamlService implements SingletonInterface
     /**
      * Redirects the user to SSO Service
      *
-     * @throws \OneLogin\Saml2\Error
+     * @throws Error
      */
     public function redirectUserToSSO(): void
     {
@@ -76,7 +80,7 @@ final class SamlService implements SingletonInterface
     /**
      * Redirects user to SAML logout (SLO)
      *
-     * @throws \OneLogin\Saml2\Error
+     * @throws Error
      */
     public function redirectUserToLogout(?string $nameId, ?string $sessionIndex): void
     {
@@ -97,8 +101,8 @@ final class SamlService implements SingletonInterface
     /**
      * Returns the SAML Response from POST data
      *
-     * @throws \OneLogin\Saml2\Error
-     * @throws \OneLogin\Saml2\ValidationError
+     * @throws Error
+     * @throws ValidationError
      */
     public function getResponse(string $postSamlResponse): Response
     {
@@ -110,12 +114,12 @@ final class SamlService implements SingletonInterface
     /**
      * Returns possible NameFormat values for TCA itemsProcFunc
      *
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function nameIdFormatItems(array &$parameters): void
     {
         $items = [];
-        $reflectionClass = new \ReflectionClass(Constants::class);
+        $reflectionClass = new ReflectionClass(Constants::class);
 
         foreach ($reflectionClass->getConstants() as $name => $value) {
             if (!str_starts_with($name, 'NAMEID_')) {
@@ -131,20 +135,19 @@ final class SamlService implements SingletonInterface
     /**
      * Returns the SAML metadata as XML string
      *
-     * @throws \OneLogin\Saml2\Error
+     * @throws Error
      */
     public function getMetadata(): string
     {
         $settings = new SamlSettings($this->getSettings()['saml']);
         $validUntil = time() + 60 * 60 * 24 * 14;
 
-        $metadata = Metadata::builder($settings->getSPData(), true, true, $validUntil, null);
-        $metadata = Metadata::addX509KeyDescriptors(
+        $metadata = Metadata::builder($settings->getSPData(), true, true, $validUntil);
+
+        return Metadata::addX509KeyDescriptors(
             $metadata,
             $this->getSettings()['saml']['sp']['x509cert']
         );
-
-        return $metadata;
     }
 
     /**
@@ -163,7 +166,7 @@ final class SamlService implements SingletonInterface
     private function buildSettings(): void
     {
         $settingsModel = $this->fetchSettings();
-        if ($settingsModel === null) {
+        if (!$settingsModel instanceof Settings) {
             return;
         }
 

--- a/Classes/Session/SamlSession.php
+++ b/Classes/Session/SamlSession.php
@@ -44,7 +44,7 @@ class SamlSession implements SingletonInterface
         }
 
         $user = $this->getUser();
-        if ($user === null) {
+        if (!$user instanceof AbstractUserAuthentication) {
             return null;
         }
 
@@ -63,7 +63,7 @@ class SamlSession implements SingletonInterface
         }
 
         $user = $this->getUser();
-        if ($user === null) {
+        if (!$user instanceof AbstractUserAuthentication) {
             return false;
         }
 

--- a/Classes/Sv/AuthenticationService.php
+++ b/Classes/Sv/AuthenticationService.php
@@ -7,6 +7,7 @@ namespace Netresearch\NrSamlAuth\Sv;
 use Netresearch\NrSamlAuth\Domain\Model\Settings;
 use Netresearch\NrSamlAuth\Domain\Repository\SettingsRepository;
 use Netresearch\NrSamlAuth\Service\SamlService;
+use OneLogin\Saml2\Error;
 use OneLogin\Saml2\Response;
 use OneLogin\Saml2\ValidationError;
 use Psr\Http\Message\ServerRequestInterface;
@@ -25,7 +26,9 @@ class AuthenticationService extends Typo3AuthService
     protected ?Response $samlResponse = null;
 
     private SettingsRepository $settingsRepository;
+
     private SamlService $samlService;
+
     private ConnectionPool $connectionPool;
 
     public function injectSettingsRepository(SettingsRepository $settingsRepository): void
@@ -48,7 +51,7 @@ class AuthenticationService extends Typo3AuthService
      *
      * @return bool|array<string, mixed>
      * @throws ValidationError
-     * @throws \OneLogin\Saml2\Error
+     * @throws Error
      */
     public function getUser(): bool|array
     {
@@ -81,7 +84,7 @@ class AuthenticationService extends Typo3AuthService
         $username = $this->getUsername($samlResponse->getAttributes());
 
         $user = $this->fetchUserRecord($username, '', [
-            'check_pid_clause' => '`pid` = \'' . $settings->getUsersPid() . '\'',
+            'check_pid_clause' => "`pid` = '" . $settings->getUsersPid() . "'",
         ] + $this->db_user);
 
         if (!is_array($user)) {
@@ -157,7 +160,7 @@ class AuthenticationService extends Typo3AuthService
     private function getSamlResponse(): string
     {
         $request = $this->getRequest();
-        if ($request === null) {
+        if (!$request instanceof ServerRequestInterface) {
             return '';
         }
 
@@ -170,7 +173,7 @@ class AuthenticationService extends Typo3AuthService
      */
     private function hasSamlResponse(): bool
     {
-        return !empty($this->getSamlResponse());
+        return !in_array($this->getSamlResponse(), ['', '0'], true);
     }
 
     /**
@@ -179,7 +182,7 @@ class AuthenticationService extends Typo3AuthService
     private function getSamlId(): int
     {
         $request = $this->getRequest();
-        if ($request === null) {
+        if (!$request instanceof ServerRequestInterface) {
             return 1;
         }
 

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -1,11 +1,14 @@
 <?php
 
-//return [];
+declare(strict_types=1);
 
+use Netresearch\NrSamlAuth\Middleware\DeepLinkSsoMiddleware;
+
+//return [];
 return [
     'frontend' => [
         'nrumauth/sso/redirect' => [
-            'target' => \Netresearch\NrSamlAuth\Middleware\DeepLinkSsoMiddleware::class,
+            'target' => DeepLinkSsoMiddleware::class,
             'after' => [
                 'typo3/cms-frontend/authentication',
             ],

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,9 +1,11 @@
 <?php
 
-defined('TYPO3') or die();
+use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
+
+defined('TYPO3') || die();
 
 (static function (): void {
-    \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
+    ExtensionUtility::registerPlugin(
         'NrSamlAuth',
         'Authentication',
         'Saml Authentication'

--- a/Configuration/TCA/tx_nrsamlauth_domain_model_settings.php
+++ b/Configuration/TCA/tx_nrsamlauth_domain_model_settings.php
@@ -1,5 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
+use Netresearch\NrSamlAuth\Service\SamlService;
+
 return [
     'ctrl' => [
         'label' => 'name',
@@ -71,7 +75,7 @@ return [
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
-                'itemsProcFunc' => \Netresearch\NrSamlAuth\Service\SamlService::class . '->nameIdFormatItems',
+                'itemsProcFunc' => SamlService::class . '->nameIdFormatItems',
                 'required' => true,
             ],
         ],

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Self-documenting: run 'make' or 'make help' to see available targets
 
 .DEFAULT_GOAL := help
-.PHONY: help install test cgl cgl-fix quality ci clean docs up start stop restart install-v12 install-v13 install-all urls ssh phpstan phpstan-baseline
+.PHONY: help install test cgl cgl-fix quality ci clean docs up start stop restart install-v12 install-v13 install-all urls ssh phpstan phpstan-baseline rector rector-fix
 
 # Colors for output
 BLUE := \033[34m
@@ -50,7 +50,15 @@ phpstan-baseline: ## Generate PHPStan baseline
 	@echo "$(BLUE)Generating PHPStan baseline...$(RESET)"
 	@composer ci:test:php:phpstan:baseline
 
-quality: cgl phpstan ## Run all code quality checks
+rector: ## Check for pending Rector migrations (dry-run)
+	@echo "$(BLUE)Running Rector...$(RESET)"
+	@composer ci:test:php:rector
+
+rector-fix: ## Apply Rector migrations
+	@echo "$(BLUE)Applying Rector migrations...$(RESET)"
+	@composer ci:rector
+
+quality: cgl phpstan rector ## Run all code quality checks
 
 ##@ CI/CD
 

--- a/Tests/Functional/Helper/MockIdpProvider.php
+++ b/Tests/Functional/Helper/MockIdpProvider.php
@@ -12,20 +12,20 @@ namespace Netresearch\NrSamlAuth\Tests\Functional\Helper;
 final class MockIdpProvider
 {
     private string $entityId = 'https://mock-idp.example.com';
-    private string $ssoUrl = 'https://mock-idp.example.com/sso';
-    private string $sloUrl = 'https://mock-idp.example.com/slo';
-    private ?string $certificate = null;
-    private array $defaultAttributes = [];
-    private array $userDatabase = [];
 
-    public function __construct()
-    {
-        $this->defaultAttributes = [
-            'email' => 'user@example.com',
-            'firstName' => 'Mock',
-            'lastName' => 'User',
-        ];
-    }
+    private string $ssoUrl = 'https://mock-idp.example.com/sso';
+
+    private string $sloUrl = 'https://mock-idp.example.com/slo';
+
+    private ?string $certificate = null;
+
+    private array $defaultAttributes = [
+        'email' => 'user@example.com',
+        'firstName' => 'Mock',
+        'lastName' => 'User',
+    ];
+
+    private array $userDatabase = [];
 
     public function withEntityId(string $entityId): self
     {
@@ -222,24 +222,24 @@ XML;
      */
     private function getDefaultCertificate(): string
     {
-        return <<<CERT
------BEGIN CERTIFICATE-----
-MIICpDCCAYwCCQDU+pQ4P3UtbzANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDDAls
-b2NhbGhvc3QwHhcNMjQwMTAxMDAwMDAwWhcNMjUwMTAxMDAwMDAwWjAUMRIwEAYD
-VQQDDAlsb2NhbGhvc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC7
-o5e7XvJmFHBQowg3OH4wYZP+RRZ4h3rO9aLZvM8KZzWDd7VJWHhESpRYmPu0bnPe
-xEoH3sN+pPvCugxUoI7GORw3sYr4IVj8JQQqC3+WmgCqLxu5pGaK0ycvZGbIz0qp
-kL6bR9F7E1VH0lMRjCcQnSRoGEVjP3WXH1VlpKCFz3bvaKR5B7qLQXWJC8vVFJyU
-bXE0xN3W2xvLTB8F0VPiNDXpXh5LM3GxLWHN5fMaNqPfE+JjF7mC7DXeCI/y6dnZ
-QQP0JF8yMFP5DAcOPfvlSqEAgUpK9IypLe/z0HJr7LFmBcXKMxLNNQY/BZ2UT0YG
-T7KBpxh1aPFM9kq5r4l1AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAHVKSbDddMi8
-Y7zK5aEXL4ZKKLbUF4TGHjlJE1VIu9WW+K7BgQc2RPbSXAqrWTn/UEzYCXqGEC/2
-KRAKiFg5Vmk4rIpZBPR1VH6HT+kvHk5fPhDM3GxQiRK6K+7e0u4Lp5zjzMV4EUoX
-v0C5XVCpk0v3ON6S0tnVnJXDQGIwW2lFbnfzP4tXk8VgR7F9GhsH7K4PdGdLgQrr
-ehIJBJPpS7BN9LBad96u4mS9MSPW3VaReAPxvmS1aphJGsBhXe7MnYzNJQGyC8By
-k8G/fDvl2G0PG5nKLCVoF4TdFQ9R7BfT3WmBvIXwFHRey3VThgQoSt8U3RVx4tCi
-mL5PAm5KI7Y=
------END CERTIFICATE-----
-CERT;
+        return <<<CERT_WRAP
+        -----BEGIN CERTIFICATE-----
+        MIICpDCCAYwCCQDU+pQ4P3UtbzANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDDAls
+        b2NhbGhvc3QwHhcNMjQwMTAxMDAwMDAwWhcNMjUwMTAxMDAwMDAwWjAUMRIwEAYD
+        VQQDDAlsb2NhbGhvc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC7
+        o5e7XvJmFHBQowg3OH4wYZP+RRZ4h3rO9aLZvM8KZzWDd7VJWHhESpRYmPu0bnPe
+        xEoH3sN+pPvCugxUoI7GORw3sYr4IVj8JQQqC3+WmgCqLxu5pGaK0ycvZGbIz0qp
+        kL6bR9F7E1VH0lMRjCcQnSRoGEVjP3WXH1VlpKCFz3bvaKR5B7qLQXWJC8vVFJyU
+        bXE0xN3W2xvLTB8F0VPiNDXpXh5LM3GxLWHN5fMaNqPfE+JjF7mC7DXeCI/y6dnZ
+        QQP0JF8yMFP5DAcOPfvlSqEAgUpK9IypLe/z0HJr7LFmBcXKMxLNNQY/BZ2UT0YG
+        T7KBpxh1aPFM9kq5r4l1AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAHVKSbDddMi8
+        Y7zK5aEXL4ZKKLbUF4TGHjlJE1VIu9WW+K7BgQc2RPbSXAqrWTn/UEzYCXqGEC/2
+        KRAKiFg5Vmk4rIpZBPR1VH6HT+kvHk5fPhDM3GxQiRK6K+7e0u4Lp5zjzMV4EUoX
+        v0C5XVCpk0v3ON6S0tnVnJXDQGIwW2lFbnfzP4tXk8VgR7F9GhsH7K4PdGdLgQrr
+        ehIJBJPpS7BN9LBad96u4mS9MSPW3VaReAPxvmS1aphJGsBhXe7MnYzNJQGyC8By
+        k8G/fDvl2G0PG5nKLCVoF4TdFQ9R7BfT3WmBvIXwFHRey3VThgQoSt8U3RVx4tCi
+        mL5PAm5KI7Y=
+        -----END CERTIFICATE-----
+        CERT_WRAP;
     }
 }

--- a/Tests/Functional/Helper/SamlAssertionFactory.php
+++ b/Tests/Functional/Helper/SamlAssertionFactory.php
@@ -44,7 +44,7 @@ final class SamlAssertionFactory
             'displayName' => $firstName . ' ' . $lastName,
         ], $additionalAttributes);
 
-        if (!empty($groups)) {
+        if ($groups !== []) {
             $attributes['groups'] = $groups;
         }
 
@@ -115,7 +115,7 @@ final class SamlAssertionFactory
             'cn' => $firstName . ' ' . $lastName,
         ], $additionalAttributes);
 
-        if (!empty($usergroups)) {
+        if ($usergroups !== []) {
             $attributes['memberOf'] = $usergroups;
         }
 

--- a/Tests/Functional/Helper/SamlResponseBuilder.php
+++ b/Tests/Functional/Helper/SamlResponseBuilder.php
@@ -164,11 +164,6 @@ final class SamlResponseBuilder
         return $clone;
     }
 
-    public function encrypted(): self
-    {
-        return clone $this;
-    }
-
     public function build(): string
     {
         $issueInstant = $this->issueInstant->format('Y-m-d\TH:i:s\Z');

--- a/Tests/Functional/Helper/SamlResponseBuilder.php
+++ b/Tests/Functional/Helper/SamlResponseBuilder.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Netresearch\NrSamlAuth\Tests\Functional\Helper;
 
+use DateTimeImmutable;
+
 /**
  * Builds SAML Response XML for testing purposes.
  *
@@ -14,26 +16,38 @@ namespace Netresearch\NrSamlAuth\Tests\Functional\Helper;
 final class SamlResponseBuilder
 {
     private string $issuer = 'https://idp.example.com';
+
     private string $destination = 'https://sp.example.com/acs';
+
     private string $audience = 'https://sp.example.com';
+
     private string $nameId = 'user@example.com';
+
     private string $nameIdFormat = 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress';
+
     private string $sessionIndex = '_session_index_12345';
+
     private array $attributes = [];
-    private ?\DateTimeImmutable $issueInstant = null;
-    private ?\DateTimeImmutable $notBefore = null;
-    private ?\DateTimeImmutable $notOnOrAfter = null;
+
+    private ?DateTimeImmutable $issueInstant;
+
+    private ?DateTimeImmutable $notBefore;
+
+    private ?DateTimeImmutable $notOnOrAfter;
+
     private string $responseId;
+
     private string $assertionId;
+
     private string $statusCode = 'urn:oasis:names:tc:SAML:2.0:status:Success';
+
     private bool $includeSignature = false;
-    private bool $encrypted = false;
 
     public function __construct()
     {
         $this->responseId = '_' . bin2hex(random_bytes(16));
         $this->assertionId = '_' . bin2hex(random_bytes(16));
-        $this->issueInstant = new \DateTimeImmutable();
+        $this->issueInstant = new DateTimeImmutable();
         $this->notBefore = $this->issueInstant->modify('-5 minutes');
         $this->notOnOrAfter = $this->issueInstant->modify('+5 minutes');
     }
@@ -66,6 +80,7 @@ final class SamlResponseBuilder
         if ($format !== null) {
             $clone->nameIdFormat = $format;
         }
+
         return $clone;
     }
 
@@ -85,24 +100,25 @@ final class SamlResponseBuilder
         foreach ($attributes as $name => $value) {
             $clone = $clone->withAttribute($name, $value);
         }
+
         return $clone;
     }
 
-    public function withIssueInstant(\DateTimeImmutable $instant): self
+    public function withIssueInstant(DateTimeImmutable $instant): self
     {
         $clone = clone $this;
         $clone->issueInstant = $instant;
         return $clone;
     }
 
-    public function withNotBefore(\DateTimeImmutable $notBefore): self
+    public function withNotBefore(DateTimeImmutable $notBefore): self
     {
         $clone = clone $this;
         $clone->notBefore = $notBefore;
         return $clone;
     }
 
-    public function withNotOnOrAfter(\DateTimeImmutable $notOnOrAfter): self
+    public function withNotOnOrAfter(DateTimeImmutable $notOnOrAfter): self
     {
         $clone = clone $this;
         $clone->notOnOrAfter = $notOnOrAfter;
@@ -112,7 +128,7 @@ final class SamlResponseBuilder
     public function expired(): self
     {
         $clone = clone $this;
-        $clone->issueInstant = new \DateTimeImmutable('-1 hour');
+        $clone->issueInstant = new DateTimeImmutable('-1 hour');
         $clone->notBefore = $clone->issueInstant->modify('-5 minutes');
         $clone->notOnOrAfter = $clone->issueInstant->modify('+5 minutes');
         return $clone;
@@ -121,7 +137,7 @@ final class SamlResponseBuilder
     public function notYetValid(): self
     {
         $clone = clone $this;
-        $clone->issueInstant = new \DateTimeImmutable('+1 hour');
+        $clone->issueInstant = new DateTimeImmutable('+1 hour');
         $clone->notBefore = $clone->issueInstant;
         $clone->notOnOrAfter = $clone->issueInstant->modify('+5 minutes');
         return $clone;
@@ -150,9 +166,7 @@ final class SamlResponseBuilder
 
     public function encrypted(): self
     {
-        $clone = clone $this;
-        $clone->encrypted = true;
-        return $clone;
+        return clone $this;
     }
 
     public function build(): string
@@ -164,7 +178,7 @@ final class SamlResponseBuilder
         $attributeStatements = $this->buildAttributeStatement();
         $signature = $this->includeSignature ? $this->buildSignaturePlaceholder() : '';
 
-        $xml = <<<XML
+        return <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
                 xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
@@ -204,8 +218,6 @@ final class SamlResponseBuilder
     </saml:Assertion>
 </samlp:Response>
 XML;
-
-        return $xml;
     }
 
     public function buildBase64Encoded(): string
@@ -215,7 +227,7 @@ XML;
 
     private function buildAttributeStatement(): string
     {
-        if (empty($this->attributes)) {
+        if ($this->attributes === []) {
             return '';
         }
 
@@ -239,9 +251,8 @@ XML;
 
             $statements .= '</saml:Attribute>';
         }
-        $statements .= '</saml:AttributeStatement>';
 
-        return $statements;
+        return $statements . '</saml:AttributeStatement>';
     }
 
     private function buildSignaturePlaceholder(): string

--- a/Tests/Functional/Saml/SamlProtocolTest.php
+++ b/Tests/Functional/Saml/SamlProtocolTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Netresearch\NrSamlAuth\Tests\Functional\Saml;
 
+use DateTimeImmutable;
+use DOMDocument;
+use DOMXPath;
 use Netresearch\NrSamlAuth\Tests\Functional\Helper\MockIdpProvider;
 use Netresearch\NrSamlAuth\Tests\Functional\Helper\SamlAssertionFactory;
 use Netresearch\NrSamlAuth\Tests\Functional\Helper\SamlResponseBuilder;
@@ -33,7 +36,7 @@ final class SamlProtocolTest extends FunctionalTestCase
     {
         $xml = file_get_contents($this->fixturesPath . 'valid_response_user_attributes.xml');
 
-        $dom = new \DOMDocument();
+        $dom = new DOMDocument();
         $result = @$dom->loadXML($xml);
 
         self::assertTrue($result, 'Fixture XML should be well-formed');
@@ -43,10 +46,10 @@ final class SamlProtocolTest extends FunctionalTestCase
     public function validResponseFixtureContainsRequiredElements(): void
     {
         $xml = file_get_contents($this->fixturesPath . 'valid_response_user_attributes.xml');
-        $dom = new \DOMDocument();
+        $dom = new DOMDocument();
         $dom->loadXML($xml);
 
-        $xpath = new \DOMXPath($dom);
+        $xpath = new DOMXPath($dom);
         $xpath->registerNamespace('samlp', 'urn:oasis:names:tc:SAML:2.0:protocol');
         $xpath->registerNamespace('saml', 'urn:oasis:names:tc:SAML:2.0:assertion');
 
@@ -63,10 +66,10 @@ final class SamlProtocolTest extends FunctionalTestCase
     public function validResponseFixtureContainsExpectedAttributes(): void
     {
         $xml = file_get_contents($this->fixturesPath . 'valid_response_user_attributes.xml');
-        $dom = new \DOMDocument();
+        $dom = new DOMDocument();
         $dom->loadXML($xml);
 
-        $xpath = new \DOMXPath($dom);
+        $xpath = new DOMXPath($dom);
         $xpath->registerNamespace('saml', 'urn:oasis:names:tc:SAML:2.0:assertion');
 
         $attributes = $xpath->query('//saml:Attribute/@Name');
@@ -85,17 +88,17 @@ final class SamlProtocolTest extends FunctionalTestCase
     public function expiredAssertionFixtureHasPastTimestamps(): void
     {
         $xml = file_get_contents($this->fixturesPath . 'expired_assertion.xml');
-        $dom = new \DOMDocument();
+        $dom = new DOMDocument();
         $dom->loadXML($xml);
 
-        $xpath = new \DOMXPath($dom);
+        $xpath = new DOMXPath($dom);
         $xpath->registerNamespace('saml', 'urn:oasis:names:tc:SAML:2.0:assertion');
 
         $conditions = $xpath->query('//saml:Conditions')->item(0);
-        $notOnOrAfter = new \DateTimeImmutable($conditions->getAttribute('NotOnOrAfter'));
+        $notOnOrAfter = new DateTimeImmutable($conditions->getAttribute('NotOnOrAfter'));
 
         self::assertLessThan(
-            new \DateTimeImmutable(),
+            new DateTimeImmutable(),
             $notOnOrAfter,
             'Expired assertion should have NotOnOrAfter in the past'
         );
@@ -105,10 +108,10 @@ final class SamlProtocolTest extends FunctionalTestCase
     public function wrongAudienceFixtureHasIncorrectAudience(): void
     {
         $xml = file_get_contents($this->fixturesPath . 'wrong_audience.xml');
-        $dom = new \DOMDocument();
+        $dom = new DOMDocument();
         $dom->loadXML($xml);
 
-        $xpath = new \DOMXPath($dom);
+        $xpath = new DOMXPath($dom);
         $xpath->registerNamespace('saml', 'urn:oasis:names:tc:SAML:2.0:assertion');
 
         $audience = $xpath->query('//saml:Audience')->item(0)->nodeValue;
@@ -130,10 +133,10 @@ final class SamlProtocolTest extends FunctionalTestCase
     public function failedStatusFixtureContainsErrorStatus(): void
     {
         $xml = file_get_contents($this->fixturesPath . 'failed_status.xml');
-        $dom = new \DOMDocument();
+        $dom = new DOMDocument();
         $dom->loadXML($xml);
 
-        $xpath = new \DOMXPath($dom);
+        $xpath = new DOMXPath($dom);
         $xpath->registerNamespace('samlp', 'urn:oasis:names:tc:SAML:2.0:protocol');
 
         $statusCode = $xpath->query('//samlp:StatusCode/@Value')->item(0)->nodeValue;
@@ -155,12 +158,12 @@ final class SamlProtocolTest extends FunctionalTestCase
 
         $xml = $builder->build();
 
-        $dom = new \DOMDocument();
+        $dom = new DOMDocument();
         $result = $dom->loadXML($xml);
 
         self::assertTrue($result);
 
-        $xpath = new \DOMXPath($dom);
+        $xpath = new DOMXPath($dom);
         $xpath->registerNamespace('saml', 'urn:oasis:names:tc:SAML:2.0:assertion');
 
         $nameId = $xpath->query('//saml:NameID')->item(0)->nodeValue;
@@ -183,7 +186,7 @@ final class SamlProtocolTest extends FunctionalTestCase
         $decoded = base64_decode($response['SAMLResponse'], true);
         self::assertNotFalse($decoded);
 
-        $dom = new \DOMDocument();
+        $dom = new DOMDocument();
         self::assertTrue(@$dom->loadXML($decoded));
     }
 
@@ -229,7 +232,7 @@ final class SamlProtocolTest extends FunctionalTestCase
 
         $metadata = $idp->getMetadataXml();
 
-        $dom = new \DOMDocument();
+        $dom = new DOMDocument();
         self::assertTrue(@$dom->loadXML($metadata));
 
         self::assertStringContainsString('https://custom-idp.example.com', $metadata);
@@ -284,7 +287,7 @@ final class SamlProtocolTest extends FunctionalTestCase
     {
         $xml = file_get_contents($this->fixturesPath . $filename);
 
-        $dom = new \DOMDocument();
+        $dom = new DOMDocument();
         $result = @$dom->loadXML($xml);
 
         self::assertTrue($result, "Fixture '$filename' should be well-formed XML");

--- a/Tests/Unit/Helper/SamlResponseBuilderTest.php
+++ b/Tests/Unit/Helper/SamlResponseBuilderTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Netresearch\NrSamlAuth\Tests\Unit\Helper;
 
+use DateTimeImmutable;
+use DOMDocument;
 use Netresearch\NrSamlAuth\Tests\Functional\Helper\SamlResponseBuilder;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
@@ -19,7 +21,7 @@ final class SamlResponseBuilderTest extends UnitTestCase
         $builder = new SamlResponseBuilder();
         $xml = $builder->build();
 
-        $dom = new \DOMDocument();
+        $dom = new DOMDocument();
         $result = $dom->loadXML($xml);
 
         self::assertTrue($result, 'Generated XML should be valid');
@@ -119,8 +121,8 @@ final class SamlResponseBuilderTest extends UnitTestCase
         preg_match('/NotOnOrAfter="([^"]+)"/', $xml, $matches);
         self::assertNotEmpty($matches[1]);
 
-        $notOnOrAfter = new \DateTimeImmutable($matches[1]);
-        self::assertLessThan(new \DateTimeImmutable(), $notOnOrAfter);
+        $notOnOrAfter = new DateTimeImmutable($matches[1]);
+        self::assertLessThan(new DateTimeImmutable(), $notOnOrAfter);
     }
 
     #[Test]
@@ -132,8 +134,8 @@ final class SamlResponseBuilderTest extends UnitTestCase
         preg_match('/NotBefore="([^"]+)"/', $xml, $matches);
         self::assertNotEmpty($matches[1]);
 
-        $notBefore = new \DateTimeImmutable($matches[1]);
-        self::assertGreaterThan(new \DateTimeImmutable(), $notBefore);
+        $notBefore = new DateTimeImmutable($matches[1]);
+        self::assertGreaterThan(new DateTimeImmutable(), $notBefore);
     }
 
     #[Test]

--- a/Tests/Unit/Middleware/DeepLinkSsoMiddlewareTest.php
+++ b/Tests/Unit/Middleware/DeepLinkSsoMiddlewareTest.php
@@ -31,7 +31,7 @@ final class DeepLinkSsoMiddlewareTest extends UnitTestCase
 
         $expectedResponse = $this->createMock(ResponseInterface::class);
         $handler = $this->createMock(RequestHandlerInterface::class);
-        $handler->expects(self::once())
+        $handler->expects($this->once())
             ->method('handle')
             ->with($request)
             ->willReturn($expectedResponse);
@@ -51,7 +51,7 @@ final class DeepLinkSsoMiddlewareTest extends UnitTestCase
 
         $expectedResponse = $this->createMock(ResponseInterface::class);
         $handler = $this->createMock(RequestHandlerInterface::class);
-        $handler->expects(self::once())
+        $handler->expects($this->once())
             ->method('handle')
             ->with($request)
             ->willReturn($expectedResponse);
@@ -71,7 +71,7 @@ final class DeepLinkSsoMiddlewareTest extends UnitTestCase
 
         $expectedResponse = $this->createMock(ResponseInterface::class);
         $handler = $this->createMock(RequestHandlerInterface::class);
-        $handler->expects(self::once())
+        $handler->expects($this->once())
             ->method('handle')
             ->with($request)
             ->willReturn($expectedResponse);
@@ -95,7 +95,7 @@ final class DeepLinkSsoMiddlewareTest extends UnitTestCase
 
         $expectedResponse = $this->createMock(ResponseInterface::class);
         $handler = $this->createMock(RequestHandlerInterface::class);
-        $handler->expects(self::once())
+        $handler->expects($this->once())
             ->method('handle')
             ->with($request)
             ->willReturn($expectedResponse);
@@ -118,7 +118,7 @@ final class DeepLinkSsoMiddlewareTest extends UnitTestCase
 
         $expectedResponse = $this->createMock(ResponseInterface::class);
         $handler = $this->createMock(RequestHandlerInterface::class);
-        $handler->expects(self::once())
+        $handler->expects($this->once())
             ->method('handle')
             ->with($request)
             ->willReturn($expectedResponse);
@@ -138,7 +138,7 @@ final class DeepLinkSsoMiddlewareTest extends UnitTestCase
 
         $expectedResponse = $this->createMock(ResponseInterface::class);
         $handler = $this->createMock(RequestHandlerInterface::class);
-        $handler->expects(self::once())
+        $handler->expects($this->once())
             ->method('handle')
             ->with($request)
             ->willReturn($expectedResponse);

--- a/Tests/Unit/Service/SamlServiceTest.php
+++ b/Tests/Unit/Service/SamlServiceTest.php
@@ -8,12 +8,14 @@ use Netresearch\NrSamlAuth\Domain\Model\Settings;
 use Netresearch\NrSamlAuth\Domain\Repository\SettingsRepository;
 use Netresearch\NrSamlAuth\Service\SamlService;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 final class SamlServiceTest extends UnitTestCase
 {
     private SamlService $subject;
-    private SettingsRepository $settingsRepository;
+
+    private SettingsRepository&MockObject $settingsRepository;
 
     protected function setUp(): void
     {
@@ -95,6 +97,7 @@ final class SamlServiceTest extends UnitTestCase
                 break;
             }
         }
+
         self::assertTrue($foundUnspecified, 'Should contain NAMEID_UNSPECIFIED constant');
     }
 }

--- a/Tests/Unit/Session/SamlSessionTest.php
+++ b/Tests/Unit/Session/SamlSessionTest.php
@@ -77,7 +77,7 @@ final class SamlSessionTest extends UnitTestCase
         $expectedData = ['id' => 1, 'AssertionId' => 'abc123', 'nameId' => 'user@example.com'];
 
         $frontendUser = $this->createMock(FrontendUserAuthentication::class);
-        $frontendUser->expects(self::once())
+        $frontendUser->expects($this->once())
             ->method('getSessionData')
             ->with('NrSamlAuth')
             ->willReturn($expectedData);
@@ -93,10 +93,10 @@ final class SamlSessionTest extends UnitTestCase
         $testData = ['id' => 1, 'AssertionId' => 'xyz789', 'nameId' => 'test@example.com'];
 
         $frontendUser = $this->createMock(FrontendUserAuthentication::class);
-        $frontendUser->expects(self::once())
+        $frontendUser->expects($this->once())
             ->method('setSessionData')
             ->with('NrSamlAuth', $testData);
-        $frontendUser->expects(self::once())
+        $frontendUser->expects($this->once())
             ->method('storeSessionData');
 
         $this->subject->setUser($frontendUser);

--- a/Tests/Unit/Sv/AuthenticationServiceTest.php
+++ b/Tests/Unit/Sv/AuthenticationServiceTest.php
@@ -7,6 +7,7 @@ namespace Netresearch\NrSamlAuth\Tests\Unit\Sv;
 use Netresearch\NrSamlAuth\Sv\AuthenticationService;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use ReflectionClass;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 final class AuthenticationServiceTest extends UnitTestCase
@@ -119,7 +120,7 @@ final class AuthenticationServiceTest extends UnitTestCase
      */
     private function invokePrivateMethod(string $methodName, array $arguments = []): mixed
     {
-        $reflection = new \ReflectionClass($this->subject);
+        $reflection = new ReflectionClass($this->subject);
         $method = $reflection->getMethod($methodName);
 
         return $method->invokeArgs($this->subject, $arguments);

--- a/composer.json
+++ b/composer.json
@@ -43,13 +43,14 @@
         "onelogin/php-saml": "^4.3.1"
     },
     "require-dev": {
-        "typo3/testing-framework": "^8.2 || ^9.0",
-        "phpunit/phpunit": "^10.5 || ^13.0",
+        "friendsofphp/php-cs-fixer": "^3.64",
+        "netresearch/typo3-ci-workflows": "^1.3",
         "phpstan/phpstan": "^1.12 || ^2.0",
         "phpstan/phpstan-phpunit": "^1.4 || ^2.0",
+        "phpunit/phpunit": "^10.5 || ^13.0",
         "saschaegerer/phpstan-typo3": "^1.10 || ^2.0 || ^3.0",
-        "friendsofphp/php-cs-fixer": "^3.64",
-        "typo3/coding-standards": "^0.8 || ^0.9"
+        "typo3/coding-standards": "^0.8 || ^0.9",
+        "typo3/testing-framework": "^8.2 || ^9.0"
     },
     "autoload": {
         "psr-4": {
@@ -66,7 +67,11 @@
         "bin-dir": ".Build/bin",
         "allow-plugins": {
             "typo3/class-alias-loader": true,
-            "typo3/cms-composer-installers": true
+            "typo3/cms-composer-installers": true,
+            "a9f/fractor-extension-installer": true,
+            "captainhook/hook-installer": true,
+            "infection/extension-installer": true,
+            "phpstan/extension-installer": false
         },
         "sort-packages": true
     },
@@ -74,14 +79,17 @@
         "ci": [
             "@ci:test:php:cgl",
             "@ci:test:php:phpstan",
+            "@ci:test:php:rector",
             "@ci:test:php:unit",
             "@ci:test:php:functional"
         ],
         "ci:cgl": "php-cs-fixer fix --config .php-cs-fixer.php",
+        "ci:rector": "rector process --config Build/rector.php",
         "ci:test:php:cgl": "php-cs-fixer fix --config .php-cs-fixer.php --dry-run --diff",
         "ci:test:php:functional": "phpunit -c Build/phpunit/FunctionalTests.xml",
         "ci:test:php:phpstan": "phpstan analyse -c phpstan.neon",
         "ci:test:php:phpstan:baseline": "phpstan analyse -c phpstan.neon --generate-baseline",
+        "ci:test:php:rector": "rector process --config Build/rector.php --dry-run",
         "ci:test:php:unit": "phpunit -c Build/phpunit/UnitTests.xml",
         "docs:clean": "rm -rf Documentation-GENERATED-temp",
         "docs:render": "docker run --rm -v $(pwd):/project -t ghcr.io/typo3-documentation/render-guides:latest --config Documentation"

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -7,7 +7,7 @@ use Netresearch\NrSamlAuth\Sv\AuthenticationService;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 
-defined('TYPO3') or die();
+defined('TYPO3') || die();
 
 (static function (): void {
     ExtensionUtility::configurePlugin(

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
-defined('TYPO3') or die();
+defined('TYPO3') || die();
 
 (static function (): void {
     ExtensionManagementUtility::addStaticFile(


### PR DESCRIPTION
This extension had no Rector config at all, so the Rector job of the shared CI workflow found no script to run and skipped with a notice. This adds `Build/rector.php` on top of the shared org config in [netresearch/typo3-ci-workflows v1.3.4](https://github.com/netresearch/typo3-ci-workflows/releases/tag/v1.3.4), the `ci:rector` / `ci:test:php:rector` scripts the reusable workflow auto-detects, the matching `make rector` / `make rector-fix` targets, and the new check in the AGENTS.md list. Same procedure as [t3x-nr-image-optimize#150](https://github.com/netresearch/t3x-nr-image-optimize/pull/150); the rule baseline is now the org's rather than a per-repo invention, which is what the [Rector 2.6.0 fleet breakage](https://github.com/netresearch/typo3-ci-workflows/pull/154) argued for.

Three deviations from the shared defaults, all repo-specific. **`phpVersion` is lowered to 8.1**, because `composer.json` requires `php: ^8.1` and CI runs an 8.1 cell — with the shared 8.2 target, `ReadOnlyClassRector` rewrote both event listeners to `final readonly class`, which is a parse error on 8.1. **`paths()` is re-declared** since it replaces instead of merging and the shared default omits `Tests/`. **`RemoveUnusedPublicMethodParameterRector` is skipped for `Classes/EventListener`**, because it dropped the event parameter from `AfterUserLoggedOutEventListener::__invoke()` and a PSR-14 listener has to keep accepting the event it is registered for.

The `^12.4` matrix cells drop the meta package through the usual `remove-dev-deps` guard, since it is unresolvable under `typo3/cms-core ^12.4` (`saschaegerer/phpstan-typo3 ^2||^3` needs cms-core >= 13.4). After that removal `require-dev` is identical to `main`, so those cells behave exactly as before and the local tool pins deliberately stay. `php-versions` now starts at 8.2: the non-matrixed CGL and Rector jobs install the full `require-dev` on the *first* entry of that array, and the meta package requires `php ^8.2` — under a platform pin of 8.1.33 composer refuses to resolve it, so leaving 8.1 first would have turned both jobs red. 8.1 remains in the matrix as the supported floor.

`phpstan/extension-installer` is added to `allow-plugins` as an explicit `false`. `phpstan.neon` includes the phpstan-phpunit and phpstan-typo3 extension neons by hand, and letting the installer register them as well aborts the run with "These files are included multiple times" — reproduced locally by flipping the flag to `true`. Explicit `false` keeps PHPStan's behaviour bit-for-bit unchanged and avoids the interactive prompt; curating the additional rule sets it would enable is a separate migration, as in [t3x-contexts#167](https://github.com/netresearch/t3x-contexts/pull/167).

TYPO3 coding-standards fully qualifies global classes (`import_classes: false`) while the shared Rector config calls `importNames()`, so the two tools undid each other's work on every run. `.php-cs-fixer.php` now overrides `global_namespace_import` to import, matching the org PHP-CS-Fixer baseline; Rector and CGL then reach a fixpoint after one round, proved over three alternating rounds that came back clean.

Rector's first pass rewrote 19 files. Because this is an authentication extension, every semantic rewrite in the login and session paths was checked individually for value equality: the `=== null` to `instanceof` flips all sit behind nullable return types of exactly the asserted class; `!empty($string)` becomes `!in_array($s, ['', '0'], true)`, which is precisely what `empty()` means for a string; the escaped SQL quoting becomes an equivalent double-quoted literal containing nothing interpolatable; and the dropped trailing `null` argument to `OneLogin\Saml2\Metadata::builder()` is that parameter's own default. Rector also removes the unused `SettingsRepository` constructor argument of `AuthController` — `Services.yaml` autowires without positional arguments, so DI is unaffected. The reindented certificate heredoc in the test helper is byte-identical (same length, same SHA-256, checked before and after).

Two pre-existing CGL findings, in `Tests/Unit/Session/SamlSessionTest.php` and `Tests/Unit/Middleware/DeepLinkSsoMiddlewareTest.php`, are included: `main` is already CGL-dirty there (verified on a pristine checkout), and the first CGL run over the touched tree fixes them along the way.

Verified with a CI-matched toolchain — cold install under a platform pin of 8.2.33, removed again before committing — resolving rector 2.6.1, ssch/typo3-rector 3.14.4 and phpstan 2.2.7: Rector dry-run and CGL dry-run exit 0, PHPStan reports no errors, 85 unit tests and 30 functional tests pass. No version bump and no CHANGELOG entry, per the release-flow split. Not included: `Build/Scripts/runTests.sh` has no `rector` suite, which would need a Docker run to verify and is left as a follow-up.
