### PR TITLE
chore(deps): allow the composer-normalize plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.64",
-        "netresearch/typo3-ci-workflows": "^1.3",
+        "netresearch/typo3-ci-workflows": "^1.4",
         "phpstan/phpstan": "^1.12 || ^2.0",
         "phpstan/phpstan-phpunit": "^1.4 || ^2.0",
         "phpunit/phpunit": "^10.5 || ^13.0",

--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,7 @@
         "vendor-dir": ".Build/vendor",
         "bin-dir": ".Build/bin",
         "allow-plugins": {
+            "ergebnis/composer-normalize": true,
             "typo3/class-alias-loader": true,
             "typo3/cms-composer-installers": true,
             "a9f/fractor-extension-installer": true,


### PR DESCRIPTION
This PR makes two changes to `composer.json` and nothing else: it adds `ergebnis/composer-normalize` to `config.allow-plugins`, and it raises the `netresearch/typo3-ci-workflows` floor from `^1.3` to `^1.4`. The dev-dependency dedup this branch started as was dropped — see below.

## The allow-plugins entry

`netresearch/typo3-ci-workflows` ships `ergebnis/composer-normalize` as of v1.4.0, and a Composer plugin that is not listed under `config.allow-plugins` is installed but never runs. The entry makes it run.

## Why the floor moves to `^1.4`

This is a declaration fix. It is **not** a fix for a resolution that was ever broken. A caret takes the highest matching release, so `^1.3` means `>=1.3.0 <2.0.0` and — with no committed lockfile — already resolves to v1.4.0 today, with `ergebnis/composer-normalize` present. Measured on a minimal probe with an empty `COMPOSER_CACHE_DIR`:

```
require-dev: {"netresearch/typo3-ci-workflows": "^1.3"}

$ composer update --dry-run
  - Locking ergebnis/composer-normalize (2.52.0)
  - Locking netresearch/typo3-ci-workflows (v1.4.0)
```

What `^1.3` additionally permits is a *lower* resolution in which the plugin is absent entirely:

```
require-dev: {"netresearch/typo3-ci-workflows": "^1.3"}

$ composer update --dry-run --prefer-lowest
  - Locking netresearch/typo3-ci-workflows (v1.3.0)
```

(no `ergebnis/composer-normalize` in that resolution). With `^1.4` the lowest permitted resolution is v1.4.0 and the plugin is present. So the bump alters no build today; it stops the new allow-plugins entry from naming a package that a permitted resolution is free to omit.

## Why the dedup was dropped from this PR

The branch originally also removed the dev-dependencies the shared package provides. That is wrong for this repo, and CI said so plainly in [ci / PHPStan (8.2, ^12.4)](https://github.com/netresearch/t3x-nr-saml-auth/actions/runs/30989304878/job/92251739306):

```
sh: 1: phpstan: not found
Script phpstan analyse -c phpstan.neon handling the ci:test:php:phpstan event returned with error code 127
##[error]Process completed with exit code 127.
```

`.github/workflows/ci.yml` carries

```yaml
      remove-dev-deps: '[{"dep":"netresearch/typo3-ci-workflows","only-for":"^13.4|^14.3"}]'
```

so on the **TYPO3 12.4 matrix legs the shared package is removed entirely** — it is unresolvable under `typo3/cms-core ^12.4`. On those legs the local declarations are the only source of `friendsofphp/php-cs-fixer`, `phpstan/phpstan` (with `phpstan-phpunit` and `phpstan-typo3`) and `typo3/testing-framework`. They are not duplicates at all; they are load-bearing, and they stay.

The safety net for that pass was a before/after `composer update --dry-run` comparison, and it reported the resolution unchanged. It was measuring the **default** resolution — one matrix cell out of eight (5 PHP versions × 2 TYPO3 versions, minus the two `matrix-exclude` entries). The 12.4 legs resolve differently by design, and no amount of care in reading constraints would have shown it: only running the matrix does.

Repos without a `remove-dev-deps` directive for the shared package are unaffected, and their dedup PRs stay as they are.

## Corrections to earlier revisions of this description

Three claims in earlier revisions were wrong. They are corrected above; recording them here so the wrong versions cannot be taken away from the history.

- The build error was quoted as `sh: 1: .Build/bin/phpstan: not found`. That text is not from this repository. This repo's own job log reads `sh: 1: phpstan: not found`, from the composer script `phpstan analyse -c phpstan.neon`. The correct quote and a link to the job are above.
- The tools said to be supplied only by the local declarations on the 12.4 legs included **rector**. This repo does not declare `rector` at all — the Rector job is not TYPO3-matrixed and keeps the shared package. The list above is the accurate one.
- The superseded commit message reported that the before/after dry-run produced "the same 392 packages". That figure came from counting lines matching `^  - ` in the composer output, and composer prints every package twice, once as `- Locking` and once as `- Installing`. The real figure is **196**. The conclusion is unaffected: holding the constraint at `^1.4` and comparing with and without the dedup, both resolutions lock an identical set of 196 packages (`Lock file operations: 196 installs, 0 updates, 0 removals` on both sides, and the sorted `- Locking` lists diff empty).
