### PR TITLE
ci: restore ascending php-versions order via cgl/rector-php-version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,12 @@ jobs:
     permissions:
       contents: read
     with:
-      # First entry drives the non-matrixed tool jobs (CGL, Rector), so it has to
-      # stay >= 8.2: netresearch/typo3-ci-workflows requires php ^8.2 and those
-      # jobs install the full require-dev. 8.1 stays in the matrix as the floor.
-      php-versions: '["8.2","8.1","8.3","8.4","8.5"]'
+      php-versions: '["8.1","8.2","8.3","8.4","8.5"]'
+      # The non-matrixed CGL and Rector jobs install the full require-dev, and
+      # netresearch/typo3-ci-workflows requires php ^8.2 — pin both jobs to 8.2
+      # so the 8.1 support floor can lead the matrix in natural order.
+      cgl-php-version: '8.2'
+      rector-php-version: '8.2'
       typo3-versions: '["^12.4","^13.4"]'
       matrix-exclude: '[{"php":"8.1","typo3":"^13.4"},{"php":"8.5","typo3":"^12.4"}]'
       # The meta package is unresolvable under typo3/cms-core ^12.4, so the ^12.4


### PR DESCRIPTION
[netresearch/typo3-ci-workflows#156](https://github.com/netresearch/typo3-ci-workflows/issues/156): the `php-versions` list here was reordered to 8.2-first in [800c9fe](https://github.com/netresearch/t3x-nr-saml-auth/commit/800c9fe91756459d54edef1b24fe7c955a7323ef) only because the non-matrixed CGL and Rector jobs of the reusable workflow install the full require-dev on the first list entry and the dev meta-package requires `php ^8.2` — list order was load-bearing in a non-obvious way. Both jobs now have dedicated version inputs (`rector-php-version` existed already, `cgl-php-version` was added in [netresearch/typo3-ci-workflows#161](https://github.com/netresearch/typo3-ci-workflows/pull/161)), so this PR restores the natural ascending order `["8.1","8.2","8.3","8.4","8.5"]` and pins `cgl-php-version: '8.2'` and `rector-php-version: '8.2'`. Job behavior is unchanged: CGL and Rector keep running on PHP 8.2, the 8.1 cells stay in the matrix as the support floor.

**Merge order**: [netresearch/typo3-ci-workflows#161](https://github.com/netresearch/typo3-ci-workflows/pull/161) must be merged first — this repo consumes the reusable workflow `@main`, and until the `cgl-php-version` input exists there, the workflow call in this PR fails validation (unknown input).

Local gates on this branch (YAML-only diff, no PHP files changed): actionlint 0, CGL dry-run 0, Rector dry-run (--clear-cache) 0, PHPStan 0, 85 unit tests pass (15 pre-existing PHPUnit notices, same as base).
